### PR TITLE
Add Audio PlugList and Fade Stop to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18212,5 +18212,19 @@
     "author": "Jeffry",
     "description": "Collect related notes based on links/backlinks to provide focused context for external AI chatbots. Explore note relationships visually and export the bundle.",
     "repo": "shuxueshuxue/PackUp4AI"
+  },
+  {
+  "id": "audio-pluglist",
+  "name": "Audio PlugList",
+  "author": "ragetrip",
+  "description": "Playlist-based audio player for Obsidian — folder & link playlists, mini-player, shuffle, repeat, fade-out.",
+  "repo": "ragetrip/obsidian-audio-pluglist"
+  },
+  {
+  "id": "fade-stop-media",
+  "name": "Fade & Stop Media",
+  "author": "ragetrip",
+  "description": "Adds a smooth fade-out when stopping audio. Clean pill button UI, adjustable fade, layout options.",
+  "repo": "ragetrip/obsidian-fade-stop"
   }
 ]


### PR DESCRIPTION
Add Audio PlugList and Fade & Stop Media to community plugins

This PR adds two plugins to `community-plugins.json`.

### Audio PlugList
- **id:** `audio-pluglist`
- **repo:** https://github.com/ragetrip/obsidian-audio-pluglist
- **latest release:** 1.0.3
- **assets on release:** `main.js`, `manifest.json`, `styles.css`
- **versions.json:** `{ "1.0.3": "1.8.0" }`
- **funding:** https://buymeacoffee.com/ragetrip

### Fade & Stop Media
- **id:** `fade-stop-media`
- **repo:** https://github.com/ragetrip/obsidian-fade-stop
- **latest release:** 1.4.0
- **assets on release:** `main.js`, `manifest.json`, `styles.css`
- **versions.json:** `{ "1.4.0": "1.5.0" }`
- **funding:** https://buymeacoffee.com/ragetrip

### Checklist
- [x] Repos are public.
- [x] Latest release includes `main.js` and `manifest.json` as assets (plus `styles.css`).
- [x] `manifest.json` `version` matches the release version.
- [x] `versions.json` maps the latest version to the correct `minAppVersion`.
- [x] LICENSE present (MIT).
- [x] README includes install/usage details.

Notes:
- `name` fields in `community-plugins.json` match the manifests.
- `id` fields match the manifests exactly.
